### PR TITLE
Fix "undefined undefined" case manager names

### DIFF
--- a/app/controllers/clients.js
+++ b/app/controllers/clients.js
@@ -112,14 +112,24 @@ module.exports = {
         clients = clients.filter(client => Number(client.cm) === Number(limitByUser));
       }
 
-      res.render('clients/index', {
-        hub: {
-          tab: 'clients',
-          sel: status ? 'current' : 'archived',
-        },
-        clients,
-        limitByUser: limitByUser || null,
-      });
+      Users.findAllByClientIds(clients.map(c => c.clid)).then((users) => {
+        const usersByCmid = users.reduce((a, user) => {
+          /* eslint-disable no-param-reassign */
+          a[user.cmid] = user;
+          /* eslint-enable no-param-reassign */
+          return a;
+        }, {});
+
+        res.render('clients/index', {
+          hub: {
+            tab: 'clients',
+            sel: status ? 'current' : 'archived',
+          },
+          clients,
+          usersByCmid,
+          limitByUser: limitByUser || null,
+        });
+      }).catch(res.error500);
     }).catch(res.error500);
   },
 

--- a/app/models/users.js
+++ b/app/models/users.js
@@ -110,6 +110,23 @@ class Users extends BaseModel {
     });
   }
 
+  /**
+   * @param {Array[Integer]} clientIds
+   * @return {Array[User]} User records who manage the clients in clientIds
+   */
+  static findAllByClientIds(clientIds) {
+    return new Promise((fulfill, reject) => {
+      db('cms')
+        .distinct('cms.*')
+        .innerJoin('clients', 'clients.cm', 'cms.cmid')
+        .whereIn('clients.clid', clientIds)
+      .then((users) => {
+        this._getMultiResponse(users, fulfill);
+      })
+      .catch(reject);
+    });
+  }
+
   static findByIds(userIds) {
     return new Promise((fulfill, reject) => {
       db('cms')

--- a/app/views/clients/index.ejs
+++ b/app/views/clients/index.ejs
@@ -81,9 +81,11 @@
 <% clients.forEach( function (client) { %>
   <% let clientBaseURL = `${level === "org" ? "/org" : ""}/clients/${client.clid}`; %>
   <% let lastActivity = moment.tz(client.updated, organization.tz).fromNow(); %>
+  <% let manager = usersByCmid[client.cm]; %>
+  <% let managerName = manager ? `${manager.last}, ${manager.first}` : 'Unknown'; %>
   <div  class="clientRow <%if (!client.unread) {%>inactive<%}%>" 
         data-client-color="<%= client.color_tag %>"
-        data-case-manager="<%= `${client.user_last} ${client.user_first}` %>"
+        data-case-manager="<%= managerName %>"
         data-last-activity="<%= lastActivity %>"
         data-unread="<%= client.unread %>"
         data-client-name="<%= `${client.last} ${client.middle} ${client.first}` %>">
@@ -135,9 +137,9 @@
 
     <div class="column">
       <% if (level == "org") { %>
-        <a href="<%=`/org?user=${client.user_id}&department=${client.department}`%>">
+        <a href="<%=`/org/users/${client.cm}/edit`%>">
           <span class="clientName">
-            <%=`${client.user_last}, ${client.user_first}`%>
+            <%= managerName %>
           </span>
         </a>
       <% } else { %>

--- a/app/views/clients/index.ejs
+++ b/app/views/clients/index.ejs
@@ -137,7 +137,7 @@
 
     <div class="column">
       <% if (level == "org") { %>
-        <a href="<%=`/org/users/${client.cm}/edit`%>">
+        <a href="<%=`/org?user=${client.cm}${manager ? `&department=${manager.department}` : ''}`%>">
           <span class="clientName">
             <%= managerName %>
           </span>

--- a/test/app/userModel.js
+++ b/test/app/userModel.js
@@ -1,3 +1,4 @@
+/* global describe it */
 const assert = require('assert');
 
 const Users = require('../../app/models/users');
@@ -62,6 +63,15 @@ describe('User checks', () => {
       done();
     }).catch((err) => {
       done(err);
+    });
+  });
+
+  it('finds a user with .findAllByClientIds', (done) => {
+    // clients 1 and 2 are both assigned to user 2
+    Users.findAllByClientIds([1, 2]).then((users) => {
+      users.length.should.be.exactly(1);
+      users.map(u => u.cmid).should.containDeep([2]);
+      done();
     });
   });
 });


### PR DESCRIPTION
The commit messages have more explanation. I added a method to fetch an array of Users based on the Client relationship ("clients.cm" foreign key) and then pass an indexed version of that array to the view as well.

This hopefully prevents the need for adding extra fields into the Client model just to support the relationship, though if we need to always fetch the case manager name when fetching a client perhaps we should invest in a better ORM.