### PR TITLE
Increase "patch" error threshold to 20% coverage delta

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+codecov:
+  status:
+    patch:
+      default:
+        threshold: 20%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
-codecov:
+coverage:
   status:
     patch:
       default:


### PR DESCRIPTION
The "codecov/patch" suite fails if the coverage decreases beyond a
certain point in a given pull request. This seems useful, but way too
flaky for the default value, whatever it is.

I think 20% will accomplish catching any accidental test suite removals
without being too onerous on a given PR.