### PR TITLE
Fix "last activity" sorting on clients index page

### DIFF
--- a/app/views/clients/index.ejs
+++ b/app/views/clients/index.ejs
@@ -86,7 +86,7 @@
   <div  class="clientRow <%if (!client.unread) {%>inactive<%}%>" 
         data-client-color="<%= client.color_tag %>"
         data-case-manager="<%= managerName %>"
-        data-last-activity="<%= lastActivity %>"
+        data-last-activity="<%= new Date(client.updated).getTime() %>"
         data-unread="<%= client.unread %>"
         data-client-name="<%= `${client.last} ${client.middle} ${client.first}` %>">
 


### PR DESCRIPTION
By casting the client's "updated" value to a Date object, it can be
converted to an epoch timestamp, which can be sorted lexicographically
by the existing sortBy method. (Except for when the epoch timestamp
overflows into having an extra digit, but handling that case seems like
too much trouble for now.)

Fixes #316