### PR TITLE
Fix "Current" / "Active" filters on clients index view

### DIFF
--- a/app/controllers/clients.js
+++ b/app/controllers/clients.js
@@ -87,7 +87,7 @@ function _getDailyVolumes(messages) {
 module.exports = {
 
   index(req, res) {
-    const status = !(req.query.status == 'archived' || req.query.status == 'closed');
+    const showActiveClients = req.query.status !== 'archived';
     let departmentID = req.user.department || req.query.department;
     const user = req.body.targetUser || req.user.cmid;
     const limitByUser = req.query.user || null;
@@ -100,11 +100,11 @@ module.exports = {
 
     let method;
     if (res.locals.level == 'user') {
-      method = Clients.findByUsers(user, status);
+      method = Clients.findByUsers(user, showActiveClients);
     } else if (departmentID) {
-      method = Clients.findManyByDepartmentAndStatus(departmentID, status);
+      method = Clients.findManyByDepartmentAndStatus(departmentID, showActiveClients);
     } else {
-      method = Clients.findByOrg(req.user.org, status);
+      method = Clients.findByOrg(req.user.org, showActiveClients);
     }
 
     method.then((clients) => {
@@ -123,7 +123,7 @@ module.exports = {
         res.render('clients/index', {
           hub: {
             tab: 'clients',
-            sel: status ? 'current' : 'archived',
+            sel: showActiveClients ? 'current' : 'archived',
           },
           clients,
           usersByCmid,

--- a/app/models/clients.js
+++ b/app/models/clients.js
@@ -215,6 +215,7 @@ class Clients extends BaseModel {
         .select('clients.*')
         .leftJoin('cms', 'cms.cmid', 'clients.cm')
         .where('cms.org', orgId)
+        .where('clients.active', status)
       .then(clients => this._getMultiResponse(clients, fulfill)).catch(reject);
     });
   }

--- a/public/js/operations.js
+++ b/public/js/operations.js
@@ -75,7 +75,7 @@ var checkingForNewMessages = setInterval(() => {
           number += 1;
 
           // append the new alert to the alerts list
-          const hrefLink = res.newMessages.active ? '<a href="/clients">' : '<a href="/clients?status=closed">';
+          const hrefLink = res.newMessages.active ? '<a href="/clients">' : '<a href="/clients?status=archived">';
           $('.numberRemaining').text(number);
           $('.alerts').fadeIn();
           $('.receivesNewAlertsHere').prepend(`${'<div class="alertRow">' +

--- a/test/app/clientsModel.js
+++ b/test/app/clientsModel.js
@@ -78,4 +78,12 @@ describe('Clients checks', () => {
       done();
     }).catch(done);
   });
+
+  it('does not return active clients when status = false', (done) => {
+    Clients.findByOrg(2, false)
+    .then((clients) => {
+      clients.length.should.be.exactly(0);
+      done();
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
These filters were not working on the organizational view of the client
index page due to a missing WHERE clause in a sql query.

This adds a ton of regression test coverage too.

Fixes #323