### PR TITLE
Add terraform deployment definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 npm-debug.log
 newrelic_agent.log
 coverage/
+*.tfstate
+*.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Version 4.0.0 represents the final deliverable to Salt Lake County. Future devel
 ## Set up [![Join the chat at https://gitter.im/slco-2016/clientcomm](https://badges.gitter.im/slco-2016/clientcomm.svg)](https://gitter.im/slco-2016/clientcomm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 View the [wiki](https://github.com/slco-2016/clientcomm/wiki) for instructions and assistance.
 
+
+## Deploying Clientcomm
+Are you deploying clientcomm? Check out the [Deploy README.md](/blob/master/deploy/README.md).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,26 @@
+# Clientcomm deploy configuration
+
+The configuration in this folder will help us deploy clientcomm in a more
+
+## credentials checklist
+All credentials should be exported as environment variables.
+
+* `AWS_ACCESS_KEY_ID`
+* `AWS_SECRET_ACCESS_KEY`
+* `TF_VAR_ssh_public_key_path` (e.g. `~/.ssh/clientcomm`)
+
+(TODO: Twilio, Newrelic, mailgun, gmail SMTP)
+
+## terraform usage
+Terraform will create all necessary AWS resources for a default deployment of
+clientcomm. It will output a "state file" of the resources so that subsequent
+invocations of terraform will know which resources it previously created.
+
+**This file, `terraform.tfstate`, must be kept in-sync between all team members
+issuing terraform commands.** The workflow for this is to-be-determined, but I
+imagine it will involve Dropbox and symlinks.
+
+```bash
+brew install terraform
+terraform plan
+```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,9 +1,14 @@
 # Clientcomm deploy configuration
 
-The configuration in this folder will help us deploy clientcomm in a more
+The configuration in this folder will help us deploy clientcomm in a
+repeatable, testable, and code-reviewable manner. Using tools like Terraform
+and Chef, we will (hopefully!) be able to spin up new clientcomm deploys
+easily. :rocket:
 
 ## credentials checklist
-All credentials should be exported as environment variables.
+All credentials should be exported as environment variables. One good way to do
+this is to create a `.env` file that has a number of lines like `VAR=value`.
+Then, run every command prefixed with `env $(cat .env)`.
 
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -1,0 +1,86 @@
+// This is a terraform definition for an AWS configuration of clientcomm.
+// See the README.md for more details on how to use this.
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "ssh_public_key_path" {
+  description = "The path to your SSH public key"
+}
+
+resource "aws_vpc" "clientcomm" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "clientcomm_web" {
+  vpc_id = "${aws_vpc.clientcomm.id}"
+  map_public_ip_on_launch = true
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_security_group" "clientcomm_allow_web" {
+  name = "ClientComm Allow Web"
+  description = "Allow 80/443 to our web servers"
+  vpc_id = "${aws_vpc.clientcomm.id}"
+
+  // TODO: restrict to CfA network?
+  ingress {
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_internet_gateway" "clientcomm" {
+  vpc_id = "${aws_vpc.clientcomm.id}"
+
+  tags = {
+    Name = "clientcomm"
+  }
+}
+
+resource "aws_route_table" "clientcomm" {
+  vpc_id = "${aws_vpc.clientcomm.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.clientcomm.id}"
+  }
+}
+
+resource "aws_route_table_association" "clientcomm" {
+  subnet_id = "${aws_subnet.clientcomm_web.id}"
+  route_table_id = "${aws_route_table.clientcomm.id}"
+}
+
+resource "aws_key_pair" "clientcomm_deployer" {
+  key_name = "clientcomm_deployer"
+  public_key = "${file(var.ssh_public_key_path)}"
+}
+
+resource "aws_instance" "clientcomm_web" {
+  ami = "ami-d206bdb2"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.clientcomm_web.id}"
+  vpc_security_group_ids = ["${aws_security_group.clientcomm_allow_web.id}"]
+  key_name = "${aws_key_pair.clientcomm_deployer.key_name}"
+}
+
+// TODO: Get this working by maybe manually building the provider
+// resource "twilio_phonenumber" "clientcomm" {
+//   location {
+//     near_lat_long {
+//       latitude = 45.5231
+//       longitude = -122.6765
+//     }
+//   }
+// }


### PR DESCRIPTION
Terraform is a great tool for specifying deployment configuration. As a
swiss army knife of API integrations, it can make it easy to make sure
that changes across complex deployments are made consistently, and to
introduce code review before such changes are made. Devops!

This commit adds just enough terraform configuration to create the AWS
VPC networking to get to a publicly-accessible web server. Subsequent
commits will set up RDS, additional servers, ELB's, etc. It should even
be possible to provision twilio, newrelic, and mailgun resources
declaratively with terraform, so a new deployment of clientcomm would be
just a `terraform apply` away.

More information in the deploy/README.md.