### PR TITLE
Add Twilio, RDS terraform provisioning

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,7 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`
 * `TF_VAR_ssh_public_key_path` (e.g. `~/.ssh/clientcomm`)
+* `TF_VAR_session_secret` (generate with `openssl rand -base64 80 | tr -d '\n'`)
 
 (TODO: Twilio, Newrelic, mailgun, gmail SMTP)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `TF_VAR_twilio_account_sid`
 * `TF_VAR_twilio_auth_token`
 
-(TODO: Twilio, Newrelic, mailgun, gmail SMTP)
+(TODO: Newrelic, mailgun, gmail SMTP)
 
 ## terraform usage
 Terraform will create all necessary AWS resources for a default deployment of

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,6 +14,8 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `AWS_SECRET_ACCESS_KEY`
 * `TF_VAR_ssh_public_key_path` (e.g. `~/.ssh/clientcomm`)
 * `TF_VAR_session_secret` (generate with `openssl rand -base64 80 | tr -d '\n'`)
+* `TF_VAR_twilio_account_sid`
+* `TF_VAR_twilio_auth_token`
 
 (TODO: Twilio, Newrelic, mailgun, gmail SMTP)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,6 +28,8 @@ imagine it will involve Dropbox and symlinks.
 
 ```bash
 brew install terraform
+# you will need to install https://github.com/tulip/terraform-provider-twilio
+# (TODO: better instructions)
 terraform plan
 terraform apply
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,6 +16,7 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `TF_VAR_session_secret` (generate with `openssl rand -base64 80 | tr -d '\n'`)
 * `TF_VAR_twilio_account_sid`
 * `TF_VAR_twilio_auth_token`
+* `TF_VAR_database_password` (generate with `openssl rand -base64 80 | tr -d '\n/'`)
 
 (TODO: Newrelic, mailgun, gmail SMTP)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,7 +16,7 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `TF_VAR_session_secret` (generate with `openssl rand -base64 80 | tr -d '\n'`)
 * `TF_VAR_twilio_account_sid`
 * `TF_VAR_twilio_auth_token`
-* `TF_VAR_database_password` (generate with `openssl rand -base64 80 | tr -d '\n/'`)
+* `TF_VAR_database_password` (generate with `openssl rand -base64 24 | tr -d '\n/+='`)
 
 (TODO: Newrelic, mailgun, gmail SMTP)
 

--- a/deploy/chef/cookbook/recipes/_clientcomm.rb
+++ b/deploy/chef/cookbook/recipes/_clientcomm.rb
@@ -17,6 +17,8 @@ execute 'mv /home/ubuntu/clientcomm.conf /etc/clientcomm.conf' do
   only_if '[ -f /home/ubuntu/clientcomm.conf ]'
 end
 
+package 'postgresql-client-9.5'
+
 execute 'npm install' do
   user 'clientcomm'
   cwd '/home/clientcomm/clientcomm'

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -10,6 +10,10 @@ provider "twilio" {
   auth_token = "${var.twilio_auth_token}"
 }
 
+variable "deploy_base_url" {
+  description = "The publicly-accessible URL base of this deploy (e.g. 'multnomah.clientcomm.org')"
+}
+
 // Specify this with an environment variable, something like:
 // export TF_VAR_ssh_public_key_path=~/.ssh/clientcomm.pub
 variable "ssh_public_key_path" {
@@ -24,20 +28,6 @@ variable "twilio_account_sid" {
 // Specify with TF_VAR_twilio_auth_token
 variable "twilio_auth_token" {
   description = "Twilio auth token for the account/subaccount"
-}
-
-// TODO: I think this is a constant, or at least derived from the hostname of
-// the deploy.
-variable "twilio_outbound_callback_url" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
-}
-
-// TODO: I think this is a constant, or at least derived from the hostname of
-// the deploy.
-variable "twilio_outbound_callback_url_backup" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
 }
 
 variable "session_secret" {
@@ -101,6 +91,11 @@ resource "twilio_phonenumber" "clientcomm" {
       longitude = -122.6765
     }
   }
+
+  // TODO: support fallback URLs as well, possibly with a secondary deploy URL
+  // variable
+  voice_url = "https://${var.deploy_base_url}/webhooks/voice"
+  sms_url = "https://${var.deploy_base_url}/webhooks/sms"
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -253,8 +248,8 @@ CCENV=production
 TWILIO_ACCOUNT_SID=${var.twilio_account_sid}
 TWILIO_AUTH_TOKEN=${var.twilio_auth_token}
 TWILIO_NUM=${twilio_phonenumber.clientcomm.phone_number}
-TWILIO_OUTBOUND_CALLBACK_URL=${var.twilio_outbound_callback_url}
-TWILIO_OUTBOUND_CALLBACK_URL_BACKUP=${var.twilio_outbound_callback_url_backup}
+TWILIO_OUTBOUND_CALLBACK_URL=https://${var.deploy_base_url}
+# TWILIO_OUTBOUND_CALLBACK_URL_BACKUP=https://${var.deploy_base_url}
 SESSION_SECRET=${var.session_secret}
 LOCAL_DATABASE_USER=clientcomm
 # TODO: replace these with RDS:

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -43,11 +43,8 @@ variable "twilio_outbound_callback_url_backup" {
   default = "TODO ******TODO ******TODO *******"
 }
 
-// TODO: This will have to come from the deployer's local environment and it
-// will be shared amongst all deployers of the app.
 variable "session_secret" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
+  description = "Cookie encryption key for end users"
 }
 
 // TODO: This will be determined from an RDS resource provisioned by terraform

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -89,6 +89,24 @@ resource "aws_vpc" "clientcomm" {
 }
 
 // ////////////////////////////////////////////////////////////////////////////
+// HOSTED SERVICES (TWILIO, ETC)
+// ////////////////////////////////////////////////////////////////////////////
+// NOTE: I had to build the terraform plugin for twilio myself due to an API
+// inconsistency with terraform. Installation instructions will be difficult
+// until my open issue is resolved:
+// https://github.com/tulip/terraform-provider-twilio/issues/2
+resource "twilio_phonenumber" "clientcomm" {
+  name = "clientcomm multnomah"
+
+  location {
+    near_lat_long {
+      latitude = 45.5231
+      longitude = -122.6765
+    }
+  }
+}
+
+// ////////////////////////////////////////////////////////////////////////////
 // NETWORKING
 // ////////////////////////////////////////////////////////////////////////////
 // Create a subnet to contain our web servers
@@ -237,7 +255,7 @@ resource "aws_instance" "clientcomm_web" {
 CCENV=production
 TWILIO_ACCOUNT_SID=${var.twilio_account_sid}
 TWILIO_AUTH_TOKEN=${var.twilio_auth_token}
-TWILIO_NUM=${var.twilio_num}
+TWILIO_NUM=${twilio_phonenumber.clientcomm.phone_number}
 TWILIO_OUTBOUND_CALLBACK_URL=${var.twilio_outbound_callback_url}
 TWILIO_OUTBOUND_CALLBACK_URL_BACKUP=${var.twilio_outbound_callback_url_backup}
 SESSION_SECRET=${var.session_secret}
@@ -260,13 +278,3 @@ ENV
 output "web_ip" {
   value = "${aws_instance.clientcomm_web.public_ip}"
 }
-
-// TODO: Get this working by maybe manually building the provider
-// resource "twilio_phonenumber" "clientcomm" {
-//   location {
-//     near_lat_long {
-//       latitude = 45.5231
-//       longitude = -122.6765
-//     }
-//   }
-// }

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -5,28 +5,25 @@ provider "aws" {
   region = "us-west-2"
 }
 
+provider "twilio" {
+  account_sid = "${var.twilio_account_sid}"
+  auth_token = "${var.twilio_auth_token}"
+}
+
 // Specify this with an environment variable, something like:
 // export TF_VAR_ssh_public_key_path=~/.ssh/clientcomm.pub
 variable "ssh_public_key_path" {
   description = "The path to your SSH public key"
 }
 
-// TODO: This will probably have to come from the deployer's local environment.
+// Specify with TF_VAR_twilio_account_sid
 variable "twilio_account_sid" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
+  description = "Twilio SID for the account/subaccount"
 }
 
-// TODO: This will probably have to come from the deployer's local environment.
+// Specify with TF_VAR_twilio_auth_token
 variable "twilio_auth_token" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
-}
-
-// TODO: This can probably be provisioned with terraform.
-variable "twilio_num" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
+  description = "Twilio auth token for the account/subaccount"
 }
 
 // TODO: I think this is a constant, or at least derived from the hostname of


### PR DESCRIPTION
This adds documentation for a few more configuration settings that need to be set:

* `deploy_base_url` (e.g. 'multnomah.clientcomm.org')
* `TF_VAR_database_password`
* `TF_VAR_twilio_auth_sid`/ token

But in exchange, we can automatically provision twilio numbers and make sure that their configuration is specified in code. Note that the twilio functionality for terraform is a poorly-maintained 3rd party plugin. The code appears to be of pretty good quality, but you need to build the plugin yourself. (I have a built copy locally that I will attempt to get published.)

Also, RDS. This provisions a simple, single-node database cluster. I think I got the networking right, so as to firewall it from the internet and any other stuff in the VPC that isn't in the web nodes subnet, but I need to do more testing to be sure. I wrote this TODO list in a commit message which I plan to address after I get clientcomm up and running for the first time:

- [ ] Create multiple instances, for reliability purposes
- [ ] Configure backups/snapshots
- [ ] Use a better instance type that db.t2.small (?)
- [ ] Verify security group / firewall connectivity