### PR TITLE
Add "baseUrl" config option, DNS, nginx

### DIFF
--- a/app/models/public.js
+++ b/app/models/public.js
@@ -1,5 +1,6 @@
 
 
+const { baseUrl } = require('../../credentials.js');
 const db = require('../../app/db');
 const Promise = require('bluebird');
 
@@ -8,6 +9,13 @@ class PublicView {
   static splashData() {
     return new Promise((fulfill, reject) => {
       const responseData = { overall: {} };
+
+      if (baseUrl) {
+        responseData.baseUrl = baseUrl;
+      } else {
+        console.warn('DEPRECATION WARNING: add "baseUrl: \'https://secure.clientcomm.org\'" to credentials.js');
+        responseData.baseUrl = 'https://secure.clientcomm.org';
+      }
 
       const rawQuery0 = ' SELECT count(msgid), date_trunc(\'week\', created) AS week ' +
                       ' FROM msgs GROUP BY week ORDER BY week ASC; ';

--- a/app/views/splash.ejs
+++ b/app/views/splash.ejs
@@ -288,7 +288,7 @@
             slco@codeforamerica.org
           </a>
         </span>
-        <a href="https://secure.clientcomm.org/login">
+        <a href="<%= baseUrl %>/login">
           <span class="right">Login</span>
         </a>
       </div>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,8 +17,10 @@ Then, run every command prefixed with `env $(cat .env)`.
 * `TF_VAR_twilio_account_sid`
 * `TF_VAR_twilio_auth_token`
 * `TF_VAR_database_password` (generate with `openssl rand -base64 24 | tr -d '\n/+='`)
+* `TF_VAR_newrelic_key`
+* `TF_VAR_newrelic_app_name`
 
-(TODO: Newrelic, mailgun, gmail SMTP)
+(TODO: mailgun, gmail SMTP)
 
 ## terraform usage
 Terraform will create all necessary AWS resources for a default deployment of

--- a/deploy/chef/cookbook/attributes/_nginx.rb
+++ b/deploy/chef/cookbook/attributes/_nginx.rb
@@ -1,0 +1,1 @@
+default['nginx']['pid'] = '/run/nginx.pid'

--- a/deploy/chef/cookbook/files/default/credentials.js
+++ b/deploy/chef/cookbook/files/default/credentials.js
@@ -4,6 +4,7 @@ const baseProductionReadyCredentials = {
   // Twilio-related
   accountSid: process.env.TWILIO_ACCOUNT_SID,
   authToken: process.env.TWILIO_AUTH_TOKEN,
+  baseUrl: process.env.BASE_URL,
   twilioNum: process.env.TWILIO_NUM, // e.g. '+12344564563'
   twilio: {
     // e.g. 'http://ecx-x-x-xx.us-xxx.compute.amazonaws.com'

--- a/deploy/chef/cookbook/files/default/nginx.conf
+++ b/deploy/chef/cookbook/files/default/nginx.conf
@@ -4,8 +4,14 @@ server {
 
   access_log  /var/log/nginx/clientcomm.access.log;
 
+  location /static {
+    alias /home/clientcomm/clientcomm/public/;
+  }
+
   location / {
-    root   /var/www/nginx-default;
-    index  index.html index.htm;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass http://127.0.0.1:4000;
   }
 }

--- a/deploy/chef/cookbook/recipes/_systemd.rb
+++ b/deploy/chef/cookbook/recipes/_systemd.rb
@@ -6,7 +6,7 @@ systemd_service 'clientcomm' do
   end
   service do
     environment_file '/etc/clientcomm.conf'
-    exec_start '/usr/local/bin/node app/app.js'
+    exec_start '/usr/local/bin/node app/server.js'
     working_directory '/home/clientcomm/clientcomm'
     user 'clientcomm'
     group 'clientcomm'

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -109,7 +109,7 @@ resource "aws_subnet" "clientcomm_web" {
   map_public_ip_on_launch = true
   cidr_block = "10.1.${count.index}.0/24"
   // Distribute across AZ's with modulo; 'a' has ASCII value 97.
-  availability_zone = "${format("us-west-2%c", 97 + (count.index % 4))}"
+  availability_zone = "${format("us-west-2%c", 97 + (count.index % 3))}"
   count = 3
 }
 
@@ -347,7 +347,7 @@ resource "aws_instance" "clientcomm_web" {
   key_name = "${aws_key_pair.clientcomm_deployer.key_name}"
   count = 2
   // Distribute across AZ's with modulo; 'a' has ASCII value 97.
-  availability_zone = "${format("us-west-2%c", 97 + (count.index % 4))}"
+  availability_zone = "${format("us-west-2%c", 97 + (count.index % 3))}"
 
   provisioner "file" {
     destination = "/home/ubuntu/clientcomm.conf"

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -52,10 +52,16 @@ variable "gmail_password" {
   default = "TODO ******TODO ******TODO *******"
 }
 
-// TODO: This can be provisioned by terraform.
+// Specify with TF_VAR_newrelic_key
 variable "newrelic_key" {
-  description = ""
-  default = "TODO ******TODO ******TODO *******"
+  description = "API Key for Newrelic from the Web UI"
+}
+
+// Newrelic auto-creates apps when they send data for the first time, so no
+// action is necessary from terraform here.
+// Specify with the TF_VAR_newrelic_app_name
+variable "newrelic_app_name" {
+  description = "App name for Newrelic"
 }
 
 // TODO: This can be provisioned by terraform.
@@ -317,6 +323,7 @@ DATABASE_HOST=${aws_db_instance.clientcomm.address}
 # TODO: see if we can remove this dependency
 # GMAIL_PASSWORD=
 NEWRELIC_KEY=${var.newrelic_key}
+NEWRELIC_APP_NAME=${var.newrelic_app_name}
 MAILGUN_API_KEY=${var.mailgun_api_key}
 AWS_ACCESS_KEY_ID=${aws_iam_access_key.clientcomm.id}
 AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.clientcomm.secret}

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -226,6 +226,20 @@ resource "aws_route_table_association" "clientcomm" {
   route_table_id = "${aws_route_table.clientcomm.id}"
 }
 
+// TODO: provision the DNS zone here instead of looking it up?
+data "aws_route53_zone" "clientcomm" {
+  // transform 'https://multnomah.clientcomm.org' -> 'clientcomm.org.'
+  name = "${replace(replace(var.deploy_base_url, "/https:\\/\\//", ""), "/^[^\\.]+\\./", "")}."
+}
+
+resource "aws_route53_record" "clientcomm" {
+  zone_id = "${data.aws_route53_zone.clientcomm.zone_id}"
+  name = "${replace(var.deploy_base_url, "/https:\\/\\//", "")}."
+  type = "A"
+  ttl = 60
+  records = ["${aws_instance.clientcomm_web.public_ip}"]
+}
+
 // ////////////////////////////////////////////////////////////////////////////
 // DATABASE
 // ////////////////////////////////////////////////////////////////////////////

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -71,7 +71,7 @@ variable "mailgun_api_key" {
 }
 
 resource "aws_vpc" "clientcomm" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/8"
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -72,6 +72,9 @@ variable "mailgun_api_key" {
 
 resource "aws_vpc" "clientcomm" {
   cidr_block = "10.0.0.0/8"
+  tags = {
+    Name = "clientcomm"
+  }
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -11,7 +11,7 @@ provider "twilio" {
 }
 
 variable "deploy_base_url" {
-  description = "The publicly-accessible URL base of this deploy (e.g. 'multnomah.clientcomm.org')"
+  description = "The publicly-accessible URL base of this deploy (e.g. 'https://multnomah.clientcomm.org')"
 }
 
 // Specify this with an environment variable, something like:
@@ -93,8 +93,8 @@ resource "twilio_phonenumber" "clientcomm" {
 
   // TODO: support fallback URLs as well, possibly with a secondary deploy URL
   // variable
-  voice_url = "https://${var.deploy_base_url}/webhooks/voice"
-  sms_url = "https://${var.deploy_base_url}/webhooks/sms"
+  voice_url = "${var.deploy_base_url}/webhooks/voice"
+  sms_url = "${var.deploy_base_url}/webhooks/sms"
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -310,10 +310,11 @@ resource "aws_instance" "clientcomm_web" {
     }
     content = <<ENV
 CCENV=production
+BASE_URL=${var.deploy_base_url}
 TWILIO_ACCOUNT_SID=${var.twilio_account_sid}
 TWILIO_AUTH_TOKEN=${var.twilio_auth_token}
 TWILIO_NUM=${twilio_phonenumber.clientcomm.phone_number}
-TWILIO_OUTBOUND_CALLBACK_URL=https://${var.deploy_base_url}
+TWILIO_OUTBOUND_CALLBACK_URL=${var.deploy_base_url}
 # TWILIO_OUTBOUND_CALLBACK_URL_BACKUP=https://${var.deploy_base_url}
 SESSION_SECRET=${var.session_secret}
 LOCAL_DATABASE_USER=clientcomm

--- a/devTools/initializeDeploy.js
+++ b/devTools/initializeDeploy.js
@@ -17,17 +17,16 @@ const ask = (prompt, callback) => {
   });
 };
 
-let ORG_NAME, ORG_EMAIL, ORG_TZ, DEPT_NAME, CFA_USERNAME, CFA_FIRST_NAME,
+let ORG_NAME, ORG_EMAIL, ORG_TZ, DEPT_NAME, CFA_FIRST_NAME,
   CFA_LAST_NAME;
 
 if (process.argv[2] === '--multnomah') {
   ORG_NAME = 'Multnomah County';
-  ORG_EMAIL = 'tdooner@codeforamerica.org';
+  ORG_EMAIL = 'clientcomm@codeforamerica.org';
   ORG_TZ = 'America/Los_Angeles';
   DEPT_NAME = 'Department of Community Justice';
-  CFA_USERNAME = 'tdooner@codeforamerica.org';
-  CFA_FIRST_NAME = 'Tom';
-  CFA_LAST_NAME = 'Dooner';
+  CFA_FIRST_NAME = 'Code for';
+  CFA_LAST_NAME = 'America';
 } else {
   throw new Error('No deploy information set! Call this script with an argument.');
 }
@@ -57,7 +56,6 @@ const owner = {
   org: 1,
   first: CFA_FIRST_NAME,
   last: CFA_LAST_NAME,
-  email: CFA_USERNAME,
   position: 'Officer',
   admin: true,
   active: true,
@@ -71,21 +69,24 @@ const phoneNumber = {
   organization: 1,
 };
 
-ask(`Login Password for ${CFA_USERNAME}? `, (pw) => {
-  owner.pass = hashPw(pw);
+ask(`Login email for superuser? `, (user) => {
+  ask(`Login Password for ${user}? `, (pw) => {
+    owner.email = user;
+    owner.pass = hashPw(pw);
 
-  // these need to be inserted in this order in order to satisfy foreign key
-  // constraints
-  db('orgs').insert(org)
-    .then(() => db('cms').insert(owner))
-    .then(() => db('phone_numbers').insert(phoneNumber))
-    .then(() => db('departments').insert(department))
-    .then(() => {
-      console.log('Created Org, Department, and User!')
-      process.exit(0);
-    })
-    .catch(err => {
-      console.error(err);
-      process.exit(1)
-    });
+    // these need to be inserted in this order in order to satisfy foreign key
+    // constraints
+    db('orgs').insert(org)
+      .then(() => db('cms').insert(owner))
+      .then(() => db('phone_numbers').insert(phoneNumber))
+      .then(() => db('departments').insert(department))
+      .then(() => {
+        console.log('Created Org, Department, and User!')
+        process.exit(0);
+      })
+      .catch(err => {
+        console.error(err);
+        process.exit(1)
+      });
+  });
 });

--- a/devTools/initializeDeploy.js
+++ b/devTools/initializeDeploy.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// usage: ./devTools/initializeDeploy.js --multnomah
+const db = require('../app/db');
+const readline = require('readline');
+const credentials = require('../credentials');
+const hashPw = require('../app/lib/pass').hashPw;
+
+const ask = (prompt, callback) => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.question(prompt, (answer) => {
+    callback(answer);
+    rl.close();
+  });
+};
+
+let ORG_NAME, ORG_EMAIL, ORG_TZ, DEPT_NAME, CFA_USERNAME, CFA_FIRST_NAME,
+  CFA_LAST_NAME;
+
+if (process.argv[2] === '--multnomah') {
+  ORG_NAME = 'Multnomah County';
+  ORG_EMAIL = 'tdooner@codeforamerica.org';
+  ORG_TZ = 'America/Los_Angeles';
+  DEPT_NAME = 'Department of Community Justice';
+  CFA_USERNAME = 'tdooner@codeforamerica.org';
+  CFA_FIRST_NAME = 'Tom';
+  CFA_LAST_NAME = 'Dooner';
+} else {
+  throw new Error('No deploy information set! Call this script with an argument.');
+}
+
+// create an organization
+const org = {
+  name: ORG_NAME,
+  phone: 1,
+  email: ORG_EMAIL,
+  expiration: '2100-01-01 00:00:00+00',
+  allotment: 10,
+  created: new Date(),
+  tz: ORG_TZ,
+};
+
+// create a department
+const department = {
+  organization: 1,
+  name: DEPT_NAME,
+  phone_number: 1,
+  created_by: 1,
+  active: true,
+};
+
+// create a superuser
+const owner = {
+  org: 1,
+  first: CFA_FIRST_NAME,
+  last: CFA_LAST_NAME,
+  email: CFA_USERNAME,
+  position: 'Officer',
+  admin: true,
+  active: true,
+  superuser: true,
+  class: 'owner',
+};
+
+// phone number
+const phoneNumber = {
+  value: credentials.twilioNum,
+  organization: 1,
+};
+
+ask(`Login Password for ${CFA_USERNAME}? `, (pw) => {
+  owner.pass = hashPw(pw);
+
+  // these need to be inserted in this order in order to satisfy foreign key
+  // constraints
+  db('orgs').insert(org)
+    .then(() => db('cms').insert(owner))
+    .then(() => db('phone_numbers').insert(phoneNumber))
+    .then(() => db('departments').insert(department))
+    .then(() => {
+      console.log('Created Org, Department, and User!')
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1)
+    });
+});

--- a/exampleCredentials.js
+++ b/exampleCredentials.js
@@ -18,6 +18,11 @@ const baseProductionReadyCredentials = {
   authToken: '**************************',
   twilioNum: '+12344564563',
 
+  // URL base of the current deploy
+  //   e.g. 'https://multnomah.clientcomm.org'
+  //   or 'http://localhost:4000' for local development
+  baseUrl: 'http://localhost:4000',
+
   // TODO: Move all twilio components into a single key
   twilio: {
     outboundCallbackUrl: 'http://ecx-x-x-xx.us-xxx.compute.amazonaws.com',

--- a/test/app/rootController.js
+++ b/test/app/rootController.js
@@ -1,0 +1,19 @@
+/* global describe context it before */
+const supertest = require('supertest');
+
+const APP = require('../../app/app');
+const should = require('should');
+const anonymous = supertest.agent(APP);
+
+describe('root controller', () => {
+  describe('GET /', () => {
+    it('renders a login link', (done) => {
+      anonymous.get('/')
+        .expect(200)
+        .end((err, res) => {
+          res.text.should.match(/Login/)
+          done(err);
+        });
+      });
+  });
+});


### PR DESCRIPTION
Another day's work, and finally the end is in sight. 

### baseurl option
This actually touches the clientcomm code so it's probably worth being careful to deploy carefully -- there is a new config value "baseUrl" that must be specified in each server's credentials.js file. A backwards-compatible value is the default if this value is not specified.

### newrelic
All we need to specify is the intended newrelic app name and the newrelic API key. The app will be created when data is being sent the first time. This branch doesn't yet change `newrelic.js` to use a configurable newrelic app name, but it does put the config values in the proper place for that to be easily done.

### nginx
This is the minimal work necessary to get nginx working. No TLS yet, that's somewhat unknown how we will fit that in here.

### DNS
This adds some route53 provisioning logic to terraform. This can all be determined from the value of the `baseUrl` option, though it requires some pretty gnarly string manipulation.

### initialization script
I added a script that is kind of like the seed script, but for the purpose of initializing a new installation with some actual objects. Run it like:

```bash
./devTools/initializeDeploy.js --multnomah
```