### PR TITLE
Move Keen.io to project-level configuration

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -21,6 +21,10 @@ const session = require('cookie-session');
 const flash = require('connect-flash');
 const colors = require('colors');
 
+app.locals.keenProjectId = credentials.keenProjectId || '5750a91433e4063ccd5b6c7e';
+app.locals.keenWriteKey = credentials.keenWriteKey || '57bd2513349615cb4f61859fbecf3252d67cf5820f085ce7788892b314cc9399e2bfdc084c3b5f5c60712c4c48143e7f31a9eb9e78c0955228e3cf08304bb64fa4e725862dfee3ceb3bb3298600faa954e487950dbe49b2c353167d4ceaa785f';
+app.locals.keenReadKey = credentials.keenReadKey || 'a70db21e3f6527c10ee23f2697714bf883783b6018b8f3fd27d94bf0b0d9eb9cb26a22d69709dff266866c526ad0e9e845c82dd5393b417d99c2ef7712d979a960e9247806dc09231e9ff7880ab2772cfa1b41d9900de385db8d5942d4d337bd';
+
 // CONFIGURATION 1
 app.set('view engine', 'ejs');
 app.set('views', `${__dirname}/views`);

--- a/app/views/partials/bundled.ejs
+++ b/app/views/partials/bundled.ejs
@@ -33,8 +33,8 @@
   // Keen.io tracking operations
   function createKeenClient () {
     var client = new Keen({
-      projectId: "5750a91433e4063ccd5b6c7e",
-      writeKey: "57bd2513349615cb4f61859fbecf3252d67cf5820f085ce7788892b314cc9399e2bfdc084c3b5f5c60712c4c48143e7f31a9eb9e78c0955228e3cf08304bb64fa4e725862dfee3ceb3bb3298600faa954e487950dbe49b2c353167d4ceaa785f"
+      projectId: window.clientcomm.keenProjectId,
+      writeKey: window.clientcomm.keenWriteKey
     });
     return client;
   };

--- a/app/views/partials/headerBase.ejs
+++ b/app/views/partials/headerBase.ejs
@@ -34,6 +34,13 @@
   <link rel="stylesheet" type="text/css" href="/static/css/v4_base.css">
 
   <script src="/modules/jquery/dist/jquery.min.js"></script>
+  <script>
+    window.clientcomm = window.clientcomm || {};
+
+    window.clientcomm.keenProjectId = "<%= keenProjectId %>";
+    window.clientcomm.keenWriteKey = "<%= keenWriteKey %>";
+    window.clientcomm.keenReadKey = "<%= keenReadKey %>";
+  </script>
 
   <body>
 

--- a/app/views/splash.ejs
+++ b/app/views/splash.ejs
@@ -668,8 +668,8 @@
   // Keen.io tracking operations
   function createKeenClient () {
     var client = new Keen({
-      projectId: "5750a91433e4063ccd5b6c7e",
-      writeKey: "57bd2513349615cb4f61859fbecf3252d67cf5820f085ce7788892b314cc9399e2bfdc084c3b5f5c60712c4c48143e7f31a9eb9e78c0955228e3cf08304bb64fa4e725862dfee3ceb3bb3298600faa954e487950dbe49b2c353167d4ceaa785f"
+      projectId: "<%= keenProjectId %>",
+      writeKey: "<%= keenWriteKey %>"
     });
     return client;
   };

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,7 +28,8 @@ easily. :rocket:
    lastpass as an attachment to the .env file.
 7. For the Twilio account, make sure that the "IBM Watson" add-ons are enabled
    in the "Programmable SMS Add-Ons" settings page.
-8. Create a Keen.io project for the deploy
+8. Create a Keen.io project for the deploy and add its project ID, read key,
+   and write key, to the .env file.
 
 ## actually deploying a new version of code
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,6 +26,9 @@ easily. :rocket:
 6. Generate a RSA keypair for root-level access to the web servers. (e.g.
    `ssh-keygen ~/.ssh/clientcomm-multnomah`). Upload the private key to
    lastpass as an attachment to the .env file.
+7. For the Twilio account, make sure that the "IBM Watson" add-ons are enabled
+   in the "Programmable SMS Add-Ons" settings page.
+8. Create a Keen.io project for the deploy
 
 ## actually deploying a new version of code
 ```bash
@@ -155,6 +158,9 @@ in every terminal window you have open.
 * `TF_VAR_aws_ssl_certificate_arn` (see "Setting up TLS" below)
 * `TF_VAR_mailgun_api_key`
 * `TF_VAR_s3_bucket_name` (e.g. `clientcomm-multnomah-attachments`)
+* `TF_VAR_keen_project_id`
+* `TF_VAR_keen_write_key`
+* `TF_VAR_keen_read_key`
 
 ## Setting up TLS
 TLS is managed by AWS's Certificate Manager feature. You will have to set this

--- a/deploy/chef/cookbook/files/default/credentials.js
+++ b/deploy/chef/cookbook/files/default/credentials.js
@@ -36,6 +36,9 @@ const baseProductionReadyCredentials = {
   s3: {
     bucketName: process.env.S3_BUCKET_NAME,
   },
+  keenProjectId: process.env.KEEN_PROJECT_ID,
+  keenWriteKey: process.env.KEEN_WRITE_KEY,
+  keenReadKey: process.env.KEEN_READ_KEY,
 };
 
 const colors = require('colors');

--- a/deploy/clientcomm.tf
+++ b/deploy/clientcomm.tf
@@ -85,6 +85,18 @@ variable "s3_bucket_name" {
   description = "S3 bucket to store attached media"
 }
 
+variable "keen_project_id" {
+  description = "ID of the project in Keen.io"
+}
+
+variable "keen_write_key" {
+  description = "Write key for the project in Keen"
+}
+
+variable "keen_read_key" {
+  description = "Read key for the project in Keen"
+}
+
 resource "aws_vpc" "clientcomm" {
   cidr_block = "10.0.0.0/16"
   tags = {
@@ -450,6 +462,9 @@ MAILGUN_API_KEY=${var.mailgun_api_key}
 AWS_ACCESS_KEY_ID=${aws_iam_access_key.clientcomm.id}
 AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.clientcomm.secret}
 S3_BUCKET_NAME=${aws_s3_bucket.clientcomm.bucket}
+KEEN_PROJECT_ID=${var.keen_project_id}
+KEEN_WRITE_KEY=${var.keen_write_key}
+KEEN_READ_KEY=${var.keen_read_key}
 ENV
   }
 }

--- a/exampleCredentials.js
+++ b/exampleCredentials.js
@@ -67,6 +67,10 @@ const baseProductionReadyCredentials = {
   s3: {
     bucketName: 'clientcomm-attachments',
   },
+
+  keenProjectId: '*****************************',
+  keenWriteKey: '********** VERY LONG **********',
+  keenReadKey: '********** VERY LONG **********',
 };
 
 if (CCENV == 'production') {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -367,8 +367,8 @@ $(() => {
         $(window).resize(adjustDivs);
         $(document).ready(() => {
           keenQueryClient = new Keen({
-            projectId: '5750a91433e4063ccd5b6c7e',
-            readKey: 'a70db21e3f6527c10ee23f2697714bf883783b6018b8f3fd27d94bf0b0d9eb9cb26a22d69709dff266866c526ad0e9e845c82dd5393b417d99c2ef7712d979a960e9247806dc09231e9ff7880ab2772cfa1b41d9900de385db8d5942d4d337bd',
+            projectId: window.clientcomm.keenProjectId,
+            readKey: window.clientcomm.keenReadKey,
           });
           getAndRenderUserActivity();
         });

--- a/public/js/keen.js
+++ b/public/js/keen.js
@@ -10,8 +10,8 @@
 // Keen.io tracking operations
 function createKeenClient() {
   const client = new Keen({
-    projectId: '5750a91433e4063ccd5b6c7e',
-    writeKey: '57bd2513349615cb4f61859fbecf3252d67cf5820f085ce7788892b314cc9399e2bfdc084c3b5f5c60712c4c48143e7f31a9eb9e78c0955228e3cf08304bb64fa4e725862dfee3ceb3bb3298600faa954e487950dbe49b2c353167d4ceaa785f',
+    projectId: window.clientcomm.keenProjectId,
+    writeKey: window.clientcomm.keenWriteKey,
   });
   return client;
 }

--- a/views/splash.ejs
+++ b/views/splash.ejs
@@ -642,8 +642,8 @@
   // Keen.io tracking operations
   function createKeenClient () {
     var client = new Keen({
-      projectId: "5750a91433e4063ccd5b6c7e",
-      writeKey: "57bd2513349615cb4f61859fbecf3252d67cf5820f085ce7788892b314cc9399e2bfdc084c3b5f5c60712c4c48143e7f31a9eb9e78c0955228e3cf08304bb64fa4e725862dfee3ceb3bb3298600faa954e487950dbe49b2c353167d4ceaa785f"
+      projectId: "<%= keenProjectId %>",
+      writeKey: "<%= keenWriteKey %>"
     });
     return client;
   };


### PR DESCRIPTION
To support multiple keen.io projects (one for each deployment of
clientcomm), we need to pass different project ids depending on
configuration.

Unfortunately, passing the values of the environment variables into the
client-side JS is somewhat complicated due to the lack of any JS build
step, so this commit uses express global template variables (confusingly
named "locals") to stash these in view of any rendered template. They
are stashed in the window.clientcomm global which can then be used by
any client-side JS file.

I've added the appropriate values to the LastPass-stored .env file, so
make sure to update yours if you get terraform asking you for these
values.