### PR TITLE
use querystring instead of concat strings

### DIFF
--- a/app/controllers/voice.js
+++ b/app/controllers/voice.js
@@ -1,6 +1,7 @@
 const twilio = require('twilio');
 const moment = require('moment');
 const momentTz = require('moment-timezone');
+const querystring = require('querystring');
 
 const resourceRequire = require('../lib/resourceRequire');
 
@@ -42,9 +43,14 @@ module.exports = {
 
       if (communication) {
         twilioResponse.say(
-          { voice: 'woman' }, 'Hello. Please leave a message for your case manager after the beep.');
-        const params = `?type=message&commId=${communication.commid}`;
-        const url = `/webhook/voice/save-recording/${params}`;
+          {voice: 'woman'},
+          'Hello. Please leave a message for your case manager after the beep.'
+        );
+        const params = querystring.stringify({
+          type: 'message',
+          commId: communication.commid
+        });
+        const url = `/webhook/voice/save-recording/?${params}`;
         twilioResponse.record({
           action: url,
           transcribe: true,
@@ -189,12 +195,14 @@ module.exports = {
     const commId = req.query.commId;
     const clientId = req.query.clientId;
     const deliveryDateEpoch = req.query.deliveryDate;
-
-    const params = `?type=ovm&userId=${userId}&commId=${commId}` +
-      `&deliveryDate=${deliveryDateEpoch}` +
-      `&clientId=${clientId}`;
-
-    const url = `/webhook/voice/save-recording/${params}`;
+    const params = querystring.stringify({
+      type: 'ovm',
+      userId: userId,
+      commId: commId,
+      deliveryDate: deliveryDateEpoch,
+      clientId: clientId
+    });
+    const url = `/webhook/voice/save-recording/?${params}`;
 
     const resp = twilio.TwimlResponse();
     resp.say({ voice: 'woman' }, 'Hello! Please leave your message after the beep.');

--- a/app/lib/voice.js
+++ b/app/lib/voice.js
@@ -1,4 +1,5 @@
 const Promise = require('bluebird');
+const querystring = require('querystring');
 
 const credentials = require('../../credentials');
 const ACCOUNT_SID = credentials.accountSid;
@@ -27,10 +28,13 @@ module.exports = {
   recordVoiceMessage(user, commId, clientId, deliveryDate, phoneNumber, domain) {
     // Concat parameters so that callback goes to recording endpoint with all
     // data needed to know where to save that recording at
-    let params = `?userId=${user.cmid}&commId=`;
-    params += `${commId}&deliveryDate=${deliveryDate.getTime()}`;
-    params += `&clientId=${clientId}`;
-    params += '&type=ovm';
+    const params = querystring.stringify({
+      userId: user.cmid,
+      commId: commId,
+      deliveryDate: deliveryDate.getTime(),
+      clientId: clientId,
+      type: 'ovm',
+    });
 
     // TODO: The callback URL is set in credentials
     // Problem: This requires the credentials.js file to be custom set for
@@ -48,7 +52,7 @@ module.exports = {
         })
         .then(departmentPhoneNumber => {
           const sentFromValue = departmentPhoneNumber.value;
-          const url = `${domain}/webhook/voice/record/${params}`;
+          const url = `${domain}/webhook/voice/record/?${params}`;
           const opts = {
             url,
             to: phoneNumber,

--- a/test/app/voiceController.js
+++ b/test/app/voiceController.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const supertest = require('supertest');
 const should = require('should');
+const querystring = require('querystring');
 const resourceRequire = require('../../app/lib/resourceRequire');
 
 const APP = require('../../app/app');
@@ -10,7 +11,6 @@ const OutboundVoiceMessages = resourceRequire('models', 'OutboundVoiceMessages')
 const Recordings = resourceRequire('models', 'Recordings');
 const Messages = resourceRequire('models', 'Messages');
 const mock = resourceRequire('lib', 'mock');
-
 
 const twilioAgent = supertest.agent(APP);
 
@@ -23,16 +23,18 @@ const twilioStatusUpdate = require('../data/twilioStatusUpdate');
 const twilioRecordingRequest_2 = require('../data/twilioVoiceRecording_2');
 const twilioStatusUpdate_2 = require('../data/twilioStatusUpdate_2');
 
-
 const RecordingSid = 'REde2dd4be0e7a521f8296a7390a9ab21b';
 const emptyTwilioResponse = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>';
 
 describe('Voice requests with voice controller', () => {
   it.skip('should accept a new voice recording', function (done) {
     this.timeout(6000);
-    let params = '?userId=2&clientId=1';
-    params += `&deliveryDate=${new Date().getTime()}`;
-    twilioAgent.post(`/webhook/voice/save-recording/${params}`)
+    const params = querystring.stringify({
+      userId: '2',
+      clientId: '1',
+      deliveryDate: new Date().getTime()
+    });
+    twilioAgent.post(`/webhook/voice/save-recording/?${params}`)
       .send(twilioRecordingRequest)
       .expect(200)
       .end((err, res) => {
@@ -51,12 +53,13 @@ describe('Voice requests with voice controller', () => {
     // When mock is enabled, libraries send fake responses instead of real ones
     // Example: mailgun library send back fake xml response
     mock.enable();
-
-    let params = '?userId=2&clientId=1';
-    params += `&deliveryDate=${new Date().getTime()}`;
-    params += '&type=ovm';
-
-    twilioAgent.post(`/webhook/voice/save-recording/${params}`)
+    const params = querystring.stringify({
+      userId: '2',
+      clientId: '1',
+      deliveryDate: new Date().getTime(),
+      type: 'ovm'
+    });
+    twilioAgent.post(`/webhook/voice/save-recording/?${params}`)
       .send(twilioRecordingRequest)
       .expect(200)
       .end((err, res) => {
@@ -201,8 +204,13 @@ describe('Voice requests with voice controller', () => {
   });
 
   it('should provide twiml for voice recording', (done) => {
-    const params = '?userId=HHH&commId=JJJ&deliveryDate=XXX&clientId=888';
-    twilioAgent.post(`/webhook/voice/record${params}`)
+    const params = querystring.stringify({
+      userId: 'HHH',
+      commId: 'JJJ',
+      deliveryDate: 'XXX',
+      clientId: '888'
+    });
+    twilioAgent.post(`/webhook/voice/record?${params}`)
       .expect(200)
       .end((err, resp) => {
         if (err) { return done(err); }
@@ -252,12 +260,13 @@ describe('Voice requests with voice controller', () => {
     // When mock is enabled, libraries send fake responses instead of real ones
     // Example: mailgun library send back fake xml response
     mock.enable();
-
-    let params = '?userId=2&clientId=1';
-    params += `&deliveryDate=${new Date().getTime()}`;
-    params += '&type=ovm';
-
-    twilioAgent.post(`/webhook/voice/save-recording/${params}`)
+    const params = querystring.stringify({
+      userId: '2',
+      clientId: '1',
+      deliveryDate: new Date().getTime(),
+      type: 'ovm'
+    });
+    twilioAgent.post(`/webhook/voice/save-recording/?${params}`)
       .send(twilioRecordingRequest_2)
       .expect(200)
       .end((err, res) => {
@@ -350,11 +359,8 @@ describe('Voice requests with voice controller', () => {
 
   it('should accept a new inbound voice recording (mocked)', (done) => {
     mock.enable();
-
-    let params = '?commId=2';
-    params += '&type=message';
-
-    twilioAgent.post(`/webhook/voice/save-recording/${params}`)
+    const params = querystring.stringify({commId: '2', type: 'message'});
+    twilioAgent.post(`/webhook/voice/save-recording/?${params}`)
       .send(twilioRecordingRequest_2)
       .expect(200)
       .end((err, res) => {


### PR DESCRIPTION
Using querystring to construct query strings instead of assembling strings, at the suggestion of @tdooner 

